### PR TITLE
Refine route planning API and refresh delivery dashboard

### DIFF
--- a/backend/routes_logic.py
+++ b/backend/routes_logic.py
@@ -1,4 +1,4 @@
-from math import radians, cos, sin, asin, sqrt
+from math import asin, cos, radians, sin, sqrt
 from typing import Dict, List, Tuple
 
 
@@ -15,21 +15,17 @@ def haversine_distance(origin: Tuple[float, float], destination: Tuple[float, fl
 
 
 def nearest_neighbor_route(start: Tuple[float, float], clients: List[Dict]) -> List[Dict]:
-codex/develop-web-system-for-bread-delivery-f4dix1
     remaining = [
         client
         for client in clients
         if client.get("latitude") is not None and client.get("longitude") is not None
     ]
 
-    remaining = clients.copy()
- main
     ordered: List[Dict] = []
     current = start
     while remaining:
         nearest = min(
             remaining,
-codex/develop-web-system-for-bread-delivery-f4dix1
             key=lambda client: haversine_distance(
                 current,
                 (float(client.get("latitude")), float(client.get("longitude"))),
@@ -37,11 +33,5 @@ codex/develop-web-system-for-bread-delivery-f4dix1
         )
         ordered.append(nearest)
         current = (float(nearest.get("latitude")), float(nearest.get("longitude")))
-
-            key=lambda client: haversine_distance(current, (client.get("latitude") or 0, client.get("longitude") or 0)),
-        )
-        ordered.append(nearest)
-        current = (nearest.get("latitude") or 0, nearest.get("longitude") or 0)
- main
         remaining.remove(nearest)
     return ordered

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,53 +3,70 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rotas da Fábrica de Pães</title>
+    <title>Painel de Entregas • Padaria Ideal</title>
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="/styles.css" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
- codex/develop-web-system-for-bread-delivery-f4dix1
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+    />
     <link
         rel="stylesheet"
         href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
         integrity="sha256-o9N1j7kG9z8zcb2Yh3lPjUuyPz7Fu7zyFFf0zPBC3uU="
         crossorigin=""
     />
- main
 </head>
 <body>
     <header class="app-header">
-        <h1>Gestor de Entregas da Fábrica</h1>
-        <button id="installButton" class="secondary">Instalar App</button>
+        <div class="branding">
+            <span class="badge">Fábrica de Pães</span>
+            <h1>Operações de Entrega</h1>
+            <p class="muted">Controle clientes, monte rotas e acompanhe o desempenho diário.</p>
+        </div>
+        <div class="header-actions">
+            <button id="installButton" class="secondary">Instalar aplicativo</button>
+        </div>
     </header>
+
     <main class="layout">
         <section class="card" id="summary">
-            <h2>Resumo do Dia</h2>
+            <div class="section-header">
+                <h2>Resumo do dia</h2>
+                <button id="refreshSummary" class="ghost">Atualizar</button>
+            </div>
             <div class="summary-grid">
-                <div class="summary-item">
-                    <span class="label">Clientes</span>
+                <article class="summary-item">
+                    <span class="label">Clientes ativos</span>
                     <span class="value" id="summaryClients">0</span>
-                </div>
-                <div class="summary-item">
-                    <span class="label">Entregas</span>
+                </article>
+                <article class="summary-item">
+                    <span class="label">Entregas criadas</span>
                     <span class="value" id="summaryDeliveries">0</span>
-                </div>
-                <div class="summary-item">
-                    <span class="label">Concluídas Hoje</span>
+                </article>
+                <article class="summary-item">
+                    <span class="label">Concluídas hoje</span>
                     <span class="value" id="summaryToday">0</span>
-                </div>
+                </article>
             </div>
             <div class="charts">
-                <h3>Pães entregues (últimos 14 dias)</h3>
-                <canvas id="breadsChart"></canvas>
+                <div class="chart-header">
+                    <h3>Volume entregue (14 dias)</h3>
+                    <span class="muted">Atualizado automaticamente após registrar entregas.</span>
+                </div>
+                <canvas id="breadsChart" height="140"></canvas>
             </div>
         </section>
 
         <section class="card" id="clients">
             <div class="section-header">
-                <h2>Clientes</h2>
-                <button id="refreshClients" class="secondary">Atualizar</button>
+                <div>
+                    <h2>Cadastro de clientes</h2>
+                    <p class="muted">Inclua novos pontos de entrega com endereço e coordenadas.</p>
+                </div>
+                <button id="refreshClients" class="ghost">Atualizar</button>
             </div>
             <form id="clientForm" class="form">
                 <div class="form-grid">
@@ -72,25 +89,32 @@
                         <input type="text" name="notes" />
                     </label>
                 </div>
-                <button type="submit">Cadastrar Cliente</button>
+                <div class="form-actions">
+                    <button type="submit">Adicionar cliente</button>
+                </div>
             </form>
-            <table class="data-table" id="clientsTable">
-                <thead>
-                    <tr>
-                        <th>Nome</th>
-                        <th>Telefone</th>
-                        <th>Endereço</th>
-                        <th>Latitude</th>
-                        <th>Longitude</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div class="table-wrapper">
+                <table class="data-table" id="clientsTable">
+                    <thead>
+                        <tr>
+                            <th>Nome</th>
+                            <th>Telefone</th>
+                            <th>Endereço</th>
+                            <th>Latitude</th>
+                            <th>Longitude</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
         </section>
 
         <section class="card" id="routes">
             <div class="section-header">
-                <h2>Planejamento de Rota</h2>
+                <div>
+                    <h2>Planejamento de rota</h2>
+                    <p class="muted">Defina a data, selecione clientes e visualize o trajeto no mapa.</p>
+                </div>
                 <button id="generateRoute">Gerar rota</button>
             </div>
             <div class="form-grid">
@@ -98,43 +122,47 @@
                     <input type="date" id="routeDate" />
                 </label>
                 <label>Latitude inicial
-                    <input type="number" id="startLat" step="0.000001" placeholder="-23.55" />
+                    <input type="number" id="startLat" step="0.000001" placeholder="-23.550520" />
                 </label>
                 <label>Longitude inicial
-                    <input type="number" id="startLon" step="0.000001" placeholder="-46.63" />
+                    <input type="number" id="startLon" step="0.000001" placeholder="-46.633308" />
                 </label>
             </div>
-codex/develop-web-system-for-bread-delivery-f4dix1
             <div class="route-selection">
                 <div class="route-selection__header">
                     <div>
                         <h3>Selecionar clientes</h3>
-                        <p class="muted">Escolha manualmente quais paradas entram na rota de hoje.</p>
+                        <p class="muted">Clique nas opções ou nos marcadores do mapa para incluir/excluir paradas.</p>
                     </div>
                     <div class="route-selection__controls">
                         <label>Quantidade de Ideals
                             <input type="number" id="idealCount" min="1" max="5" value="3" />
                         </label>
-                        <button type="button" id="selectIdeal" class="secondary">Selecionar Ideals</button>
+                        <button type="button" id="selectIdeal" class="ghost">Selecionar Ideals</button>
                     </div>
                 </div>
                 <div class="route-selection__list" id="routeClients"></div>
-                <p class="muted">Total selecionado: <strong id="selectedCount">0</strong></p>
+                <p class="muted">Total selecionado: <strong id="selectedCount">0</strong> clientes</p>
             </div>
-            <div class="map-wrapper">
-                <div id="map" aria-label="Mapa de clientes"></div>
+            <div class="map-panel">
+                <div class="map-wrapper">
+                    <div id="map" aria-label="Mapa de clientes"></div>
+                </div>
+                <aside class="route-panel">
+                    <h3>Ordem sugerida</h3>
+                    <ol id="routeList"></ol>
+                    <div id="routeWarnings" class="route-warnings"></div>
+                </aside>
             </div>
-            <ol id="routeList"></ol>
-            <div id="routeWarnings" class="route-warnings"></div>
-
-            <ol id="routeList"></ol>
- main
         </section>
 
         <section class="card" id="deliveries">
             <div class="section-header">
-                <h2>Entregas do Dia</h2>
-                <button id="refreshDeliveries" class="secondary">Atualizar</button>
+                <div>
+                    <h2>Agenda de entregas</h2>
+                    <p class="muted">Controle o que precisa sair e finalize entregas concluídas.</p>
+                </div>
+                <button id="refreshDeliveries" class="ghost">Atualizar</button>
             </div>
             <form id="deliveryForm" class="form">
                 <div class="form-grid">
@@ -151,20 +179,24 @@ codex/develop-web-system-for-bread-delivery-f4dix1
                         <input type="text" name="notes" />
                     </label>
                 </div>
-                <button type="submit">Agendar entrega</button>
+                <div class="form-actions">
+                    <button type="submit">Agendar entrega</button>
+                </div>
             </form>
-            <table class="data-table" id="deliveriesTable">
-                <thead>
-                    <tr>
-                        <th>Cliente</th>
-                        <th>Data</th>
-                        <th>Status</th>
-                        <th>Quantidade</th>
-                        <th>Ações</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div class="table-wrapper">
+                <table class="data-table" id="deliveriesTable">
+                    <thead>
+                        <tr>
+                            <th>Cliente</th>
+                            <th>Data</th>
+                            <th>Status</th>
+                            <th>Quantidade</th>
+                            <th class="actions">Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
         </section>
     </main>
 
@@ -174,21 +206,18 @@ codex/develop-web-system-for-bread-delivery-f4dix1
             <td class="delivery-date"></td>
             <td class="delivery-status"></td>
             <td class="delivery-quantity"></td>
-            <td>
-                <button class="complete-delivery">Registrar entrega</button>
+            <td class="actions">
+                <button class="complete-delivery ghost">Registrar entrega</button>
             </td>
         </tr>
     </template>
 
- codex/develop-web-system-for-bread-delivery-f4dix1
     <script
         src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-o9N1j7kG9z8zcb2Yh3lPjUuyPz7Fu7zyFFf0zPBC3uU="
         crossorigin=""
         defer
     ></script>
-
- main
     <script src="/app.js" defer></script>
     <script src="/chart.js" defer></script>
 </body>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,213 +1,331 @@
 :root {
+    color-scheme: light;
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: #f3f4f6;
-    color: #111827;
+    background: #f4f5fb;
+    color: #0f172a;
+}
+
+* {
+    box-sizing: border-box;
 }
 
 body {
     margin: 0;
     min-height: 100vh;
+    background: radial-gradient(circle at top, #fff9eb 0%, #f4f5fb 55%);
 }
 
 .app-header {
-    background: linear-gradient(135deg, #f97316, #facc15);
-    color: white;
-    padding: 1.5rem;
+    padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 2rem;
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 1rem;
+    align-items: flex-start;
+    gap: 2rem;
+    background: linear-gradient(135deg, #f97316, #facc15);
+    color: white;
 }
 
-.app-header h1 {
-    font-size: 1.5rem;
+.branding h1 {
+    margin: 0.25rem 0 0.75rem;
+    font-size: clamp(1.75rem, 3vw, 2.5rem);
+    font-weight: 700;
+}
+
+.branding .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    padding: 0.4rem 0.7rem;
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+}
+
+.branding p {
     margin: 0;
+    max-width: 36ch;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
 }
 
 .layout {
     display: grid;
-    gap: 1.5rem;
-    padding: 1.5rem;
+    gap: 2rem;
+    padding: clamp(1.5rem, 3vw, 3rem);
+    max-width: 1200px;
+    margin: 0 auto;
 }
 
 .card {
-    background: white;
-    border-radius: 1rem;
-    padding: 1.5rem;
-    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 1.25rem;
+    padding: clamp(1.5rem, 2vw, 2.25rem);
+    box-shadow: 0 25px 45px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(8px);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
 }
 
 .section-header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
+    align-items: flex-start;
     gap: 1rem;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.muted {
+    color: #6b7280;
+    font-size: 0.9rem;
 }
 
 .summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 1rem;
-}
-
-.summary-item {
-    background: #fef3c7;
-    border-radius: 0.75rem;
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.summary-item .label {
-    font-size: 0.875rem;
-    color: #92400e;
-}
-
-.summary-item .value {
-    font-size: 1.75rem;
-    font-weight: 700;
-}
-
-.form {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.form-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 1rem;
 }
 
-label {
+.summary-item {
+    border-radius: 1rem;
+    padding: 1.1rem;
+    background: linear-gradient(180deg, rgba(250, 224, 158, 0.35), rgba(254, 243, 199, 0.9));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.summary-item .label {
+    font-size: 0.85rem;
     font-weight: 600;
-    font-size: 0.9rem;
-    color: #1f2937;
+    color: #92400e;
+    letter-spacing: 0.03em;
+}
+
+.summary-item .value {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.charts {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem 1.25rem;
+}
+
+label {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #1f2937;
 }
 
-input, select {
-    padding: 0.6rem 0.8rem;
-    border-radius: 0.6rem;
-    border: 1px solid #d1d5db;
-    background: #f9fafb;
+input,
+select {
+    padding: 0.7rem 0.9rem;
+    border-radius: 0.85rem;
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    background: rgba(248, 250, 252, 0.95);
     font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+    outline: none;
+    border-color: #f97316;
+    box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.15);
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
 }
 
 button {
     border: none;
-    border-radius: 0.75rem;
-    padding: 0.75rem 1.5rem;
+    border-radius: 0.9rem;
+    padding: 0.8rem 1.4rem;
     font-weight: 600;
     background: #f97316;
     color: white;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
-    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.95rem;
 }
 
 button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 10px 25px rgba(249, 115, 22, 0.25);
+    box-shadow: 0 15px 35px rgba(249, 115, 22, 0.25);
 }
 
 button.secondary {
-    background: #111827;
+    background: rgba(15, 23, 42, 0.2);
+    color: #0f172a;
+    backdrop-filter: blur(2px);
 }
 
-codex/develop-web-system-for-bread-delivery-f4dix1
-.muted {
-    color: #6b7280;
-    font-size: 0.85rem;
+button.ghost {
+    background: rgba(15, 23, 42, 0.06);
+    color: inherit;
+}
+
+button.ghost:hover {
+    box-shadow: none;
+    transform: none;
+    background: rgba(15, 23, 42, 0.1);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    border-radius: 1rem;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 640px;
+}
+
+.data-table thead {
+    background: rgba(226, 232, 240, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+}
+
+.data-table th,
+.data-table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+    font-size: 0.95rem;
+}
+
+.data-table tbody tr:hover {
+    background: rgba(254, 243, 199, 0.4);
+}
+
+.data-table .actions {
+    text-align: right;
 }
 
 .route-selection {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding: 1rem;
-    background: #f9fafb;
-    border-radius: 0.75rem;
-    border: 1px solid #e5e7eb;
+    padding: 1.25rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    background: rgba(248, 250, 252, 0.75);
 }
 
 .route-selection__header {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    align-items: flex-end;
     gap: 1rem;
+    align-items: flex-end;
 }
 
 .route-selection__controls {
     display: flex;
-    gap: 0.75rem;
     align-items: center;
-}
-
-.route-selection__controls label {
-    gap: 0.25rem;
+    gap: 0.75rem;
 }
 
 .route-selection__controls input {
-    max-width: 80px;
+    max-width: 90px;
 }
 
 .route-selection__list {
     display: grid;
-    gap: 0.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    max-height: 200px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+    max-height: 240px;
     overflow-y: auto;
+    padding-right: 0.25rem;
 }
 
 .route-option {
     display: flex;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
+    gap: 0.75rem;
+    padding: 0.7rem 0.85rem;
     background: white;
-    border-radius: 0.5rem;
-    border: 1px solid #e5e7eb;
+    border-radius: 0.9rem;
+    border: 1px solid rgba(226, 232, 240, 0.9);
     align-items: flex-start;
-    font-weight: 500;
     cursor: pointer;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .route-option input {
-    width: auto;
-    margin: 0;
+    margin-top: 0.2rem;
 }
 
 .route-option strong {
-    font-size: 0.95rem;
+    font-size: 0.98rem;
 }
 
 .route-option small {
     color: #6b7280;
     display: block;
-    margin-top: 0.1rem;
+    margin-top: 0.2rem;
 }
 
 .route-option.active {
-    border-color: #f97316;
-    box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.2);
+    border-color: rgba(249, 115, 22, 0.8);
+    box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);
+    transform: translateY(-1px);
+}
+
+.map-panel {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
 }
 
 .map-wrapper {
-    width: 100%;
-    height: 320px;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     overflow: hidden;
-    border: 1px solid #e5e7eb;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    min-height: 340px;
 }
 
 #map {
@@ -219,20 +337,14 @@ codex/develop-web-system-for-bread-delivery-f4dix1
     font: inherit;
 }
 
-.route-warnings {
-    display: none;
-    font-size: 0.85rem;
-    color: #b45309;
+.route-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
-.route-warnings strong {
-    display: block;
-    margin-bottom: 0.25rem;
-}
-
-.route-warnings ul {
-    margin: 0.25rem 0 0;
-    padding-left: 1.25rem;
+.route-panel h3 {
+    margin: 0;
 }
 
 #routeList {
@@ -240,13 +352,13 @@ codex/develop-web-system-for-bread-delivery-f4dix1
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.75rem;
+    gap: 0.9rem;
 }
 
 #routeList li {
-    background: #f3f4f6;
-    padding: 0.75rem 1rem;
-    border-radius: 0.75rem;
+    background: rgba(226, 232, 240, 0.45);
+    padding: 0.85rem 1rem;
+    border-radius: 0.85rem;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
@@ -257,33 +369,34 @@ codex/develop-web-system-for-bread-delivery-f4dix1
 }
 
 #routeList small {
-    color: #6b7280;
+    color: #475569;
 }
 
- main
-.data-table {
-    width: 100%;
-    border-collapse: collapse;
+.route-warnings {
+    display: none;
+    font-size: 0.88rem;
+    color: #b45309;
+    background: rgba(254, 243, 199, 0.6);
+    padding: 0.75rem 1rem;
     border-radius: 0.75rem;
-    overflow: hidden;
+    border: 1px solid rgba(251, 191, 36, 0.4);
 }
 
-.data-table thead {
-    background: #f3f4f6;
+.route-warnings strong {
+    display: block;
+    margin-bottom: 0.4rem;
 }
 
-.data-table th, .data-table td {
-    padding: 0.75rem;
-    text-align: left;
-    border-bottom: 1px solid #e5e7eb;
-    font-size: 0.95rem;
+.route-warnings ul {
+    margin: 0;
+    padding-left: 1.1rem;
 }
 
-.data-table tbody tr:hover {
-    background: #fef3c7;
+.complete-delivery {
+    font-size: 0.9rem;
 }
 
-@media (min-width: 960px) {
+@media (min-width: 1024px) {
     .layout {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -297,13 +410,34 @@ codex/develop-web-system-for-bread-delivery-f4dix1
     }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
     .app-header {
-        justify-content: center;
-        text-align: center;
+        flex-direction: column;
+        align-items: flex-start;
     }
 
-    button {
+    .header-actions {
         width: 100%;
+        justify-content: flex-start;
+    }
+
+    button,
+    .form-actions {
+        width: 100%;
+    }
+
+    .form-actions {
+        justify-content: stretch;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
     }
 }


### PR DESCRIPTION
## Summary
- clean and harden the route-planning endpoint, ensuring enriched client data and consistent fallbacks
- simplify the routing heuristic implementation by removing duplicated code
- redesign the delivery dashboard with a modern layout, improved map/selection UX, and refreshed styles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffbbcf4f10832491efe9db05352d7b