### PR TITLE
Remove Yarn artifacts from deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+backend/delivery.db
+node_modules/

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""Backend package initialization for tests and deployments."""
+
+from .app import run  # noqa: F401

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,3 +1,7 @@
+"""SQLite helpers for the bakery delivery application."""
+
+from __future__ import annotations
+
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -35,7 +39,6 @@ CREATE TABLE IF NOT EXISTS driver_positions (
 );
 """
 
-codex/develop-web-system-for-bread-delivery-f4dix1
 IDEAL_SUPERMARKETS = (
     {
         "name": "Supermercado Ideal - Centro",
@@ -79,7 +82,6 @@ IDEAL_SUPERMARKETS = (
     },
 )
 
-main
 
 def get_connection() -> sqlite3.Connection:
     conn = sqlite3.connect(DB_PATH)
@@ -91,9 +93,7 @@ def initialize() -> None:
     conn = get_connection()
     try:
         conn.executescript(SCHEMA)
-codex/develop-web-system-for-bread-delivery-f4dix1
         seed_initial_clients(conn)
- main
         conn.commit()
     finally:
         conn.close()
@@ -127,7 +127,6 @@ def execute(query: str, params: Iterable[Any] = ()) -> int:
         return cur.lastrowid
     finally:
         conn.close()
- codex/develop-web-system-for-bread-delivery-f4dix1
 
 
 def seed_initial_clients(conn: sqlite3.Connection) -> None:
@@ -145,4 +144,3 @@ def seed_initial_clients(conn: sqlite3.Connection) -> None:
             """,
             client,
         )
-main

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,16 @@
+import backend.app as app_module
+
+
+def test_resolve_port_uses_default_when_env_missing(monkeypatch):
+    monkeypatch.delenv("PORT", raising=False)
+    assert app_module._resolve_port(8000) == 8000
+
+
+def test_resolve_port_reads_environment(monkeypatch):
+    monkeypatch.setenv("PORT", "4567")
+    assert app_module._resolve_port(8000) == 4567
+
+
+def test_resolve_port_handles_invalid_values(monkeypatch):
+    monkeypatch.setenv("PORT", "invalid")
+    assert app_module._resolve_port(9000) == 9000


### PR DESCRIPTION
## Summary
- switch the Render service back to the Python environment so it installs requirements with pip and starts the backend directly
- drop the Yarn Plug'n'Play artifacts that introduced binary files into the repository

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffc448cc40832485b7b64b5b8b8913